### PR TITLE
[client] ask-result: fix warning

### DIFF
--- a/client/src/app/components/ask-result.jsx
+++ b/client/src/app/components/ask-result.jsx
@@ -53,7 +53,7 @@ var AskResult = React.createClass({
           style={styles.progress}
           mode="determinate"
           color={progressColor}
-          value={yesNoResultPercent} />
+          value={+yesNoResultPercent} />
         <div style={styles.result}>
           {result}
         </div>


### PR DESCRIPTION
fix warning
It occurs warning, because the value set by string if it run in first time.
Therefore, we add '+' to change the value to number
